### PR TITLE
separate pthread_internal_t from stack

### DIFF
--- a/libc/bionic/pthread_exit.cpp
+++ b/libc/bionic/pthread_exit.cpp
@@ -125,10 +125,12 @@ void pthread_exit(void* return_value) {
     // pthread_internal_t is freed below with stack, not here.
     __pthread_internal_remove(thread);
 
-    if (thread->mmap_size != 0) {
+    size_t mmap_size = thread->mmap_size;
+    if (mmap_size != 0) {
       // We need to free mapped space for detached threads when they exit.
       // That's not something we can do in C.
       __hwasan_thread_exit();
+      munmap(thread, sizeof(pthread_internal_t));
       _exit_with_stack_teardown(thread->mmap_base, thread->mmap_size);
     }
   }

--- a/libc/bionic/pthread_internal.cpp
+++ b/libc/bionic/pthread_internal.cpp
@@ -73,6 +73,7 @@ static void __pthread_internal_free(pthread_internal_t* thread) {
     // Free mapped space, including thread stack and pthread_internal_t.
     munmap(thread->mmap_base, thread->mmap_size);
   }
+  munmap(thread, sizeof(pthread_internal_t));
 }
 
 void __pthread_internal_remove_and_free(pthread_internal_t* thread) {


### PR DESCRIPTION
cherry-picked from android hardening archive and made minor alterations to use new `mapping` struct. Not tested yet.

Addresses https://github.com/GrapheneOS/os_issue_tracker/issues/125