### PR TITLE
fix: realign non-muliple of PAGE_SIZE stack sizes

### DIFF
--- a/libc/bionic/pthread_create.cpp
+++ b/libc/bionic/pthread_create.cpp
@@ -219,6 +219,8 @@ int __init_thread(pthread_internal_t* thread) {
 ThreadMapping __allocate_thread_mapping(size_t stack_size, size_t stack_guard_size) {
   const StaticTlsLayout& layout = __libc_shared_globals()->static_tls_layout;
 
+  // round up if the given stack size is not in multiples of PAGE_SIZE
+  stack_size = __BIONIC_ALIGN(stack_size, PAGE_SIZE);
   size_t thread_page_size = __BIONIC_ALIGN(sizeof(pthread_internal_t), PAGE_SIZE);
 
   // Place a randomly sized gap above the stack, up to 10% as large as the stack
@@ -275,7 +277,7 @@ ThreadMapping __allocate_thread_mapping(size_t stack_size, size_t stack_guard_si
 
   if (mprotect(thread, thread_page_size + layout.size(), PROT_READ | PROT_WRITE) != 0) {
     async_safe_format_log(ANDROID_LOG_WARN, "libc",
-                          "pthread_create failed: couldn't mprotect R+W %zu-byte thread mapping region: %s",
+                          "pthread_create failed: couldn't mprotect R+W %zu-byte static TLS mapping region: %s",
                           layout.size(), strerror(errno));
     munmap(space, mmap_size);
     return {};


### PR DESCRIPTION
also improved libc bionic messages when doing mapping

Before (When FAILING):

```
cts-tf > run cts --skip-device-info --module CtsBionicTestCases --test pthread#pthread_attr_setstacksize
07-17 17:40:53 I/TestInvocation: Starting invocation for 'cts' with '[ DeviceBuildInfo{bid=6221200, serial=9AUAY1FMD3} on device '9AUAY1FMD3']
07-17 17:41:01 W/PropertyCheck: Expected "user" but found "userdebug" for property: ro.build.type
07-17 17:41:01 W/PropertyCheck: Property "persist.sys.test_harness" not found on device, cannot verify value "false"
07-17 17:41:03 D/ITestSuite: [Total Unique Modules = 2]
07-17 17:41:04 E/PushFilePreparer: Did not find any module directory for 'CtsBionicTestCases'
07-17 17:41:04 E/PushFilePreparer: Did not find any module directory for 'CtsBionicTestCases'
07-17 17:41:11 I/ModuleListener: [1/1] pthread#pthread_attr_setstacksize fail:
invalid pthread_t 0x7400000000 passed to pthread_join
pthread.pthread_attr_setstacksize terminated by signal: Aborted.
07-17 17:41:12 I/ConsoleReporter: [9AUAY1FMD3] Starting arm64-v8a CtsBionicTestCases with 1 test
07-17 17:41:12 I/ConsoleReporter: [1/1 arm64-v8a CtsBionicTestCases 9AUAY1FMD3] pthread#pthread_attr_setstacksize fail: invalid pthread_t 0x7400000000 passed to pthread_join
pthread.pthread_attr_setstacksize terminated by signal: Aborted.
07-17 17:41:12 I/ConsoleReporter: [9AUAY1FMD3] arm64-v8a CtsBionicTestCases completed in 1s. 0 passed, 1 failed, 0 not executed
07-17 17:41:15 E/PushFilePreparer: Did not find any module directory for 'CtsBionicTestCases'
07-17 17:41:16 E/PushFilePreparer: Did not find any module directory for 'CtsBionicTestCases'
07-17 17:41:23 I/ModuleListener: [1/1] pthread#pthread_attr_setstacksize fail:
bionic/tests/pthread_test.cpp:(829) Failure in test pthread.pthread_attr_setstacksize
Expected: (GetActualStackSize(attributes)) > (32*1024U + 1), actual: 32769 vs 32769
pthread.pthread_attr_setstacksize exited with exitcode 1.
07-17 17:41:23 I/ConsoleReporter: [9AUAY1FMD3] Starting armeabi-v7a CtsBionicTestCases with 1 test
07-17 17:41:23 I/ConsoleReporter: [1/1 armeabi-v7a CtsBionicTestCases 9AUAY1FMD3] pthread#pthread_attr_setstacksize fail: bionic/tests/pthread_test.cpp:(829) Failure in test pthread.pthread_attr_setstacksize
Expected: (GetActualStackSize(attributes)) > (32*1024U + 1), actual: 32769 vs 32769
pthread.pthread_attr_setstacksize exited with exitcode 1.
07-17 17:41:23 I/ConsoleReporter: [9AUAY1FMD3] armeabi-v7a CtsBionicTestCases completed in 809 ms. 0 passed, 1 failed, 0 not executed
07-17 17:41:26 I/SuiteResultReporter:
============================================
================= Results ==================
=============== Consumed Time ==============
    arm64-v8a CtsBionicTestCases: 1s
    armeabi-v7a CtsBionicTestCases: 809 ms
Total aggregated tests run time: 2s
============== Modules Preparation Times ==============
    armeabi-v7a CtsBionicTestCases => prep = 6676 ms || clean = 234 ms
    arm64-v8a CtsBionicTestCases => prep = 6613 ms || clean = 229 ms
Total preparation time: 13s  ||  Total tear down time: 463 ms
=======================================================
=============== Summary ===============
Total Run time: 33s
2/2 modules completed
Total Tests       : 2
PASSED            : 0
FAILED            : 2
============== End of Results ==============
============================================

LOGCAT LOGS:

07-17 02:50:36.603  2009  2009 W libc    : pthread_create failed: couldn't mprotect R+W 11200-byte thread mapping region: Invalid argument
07-17 02:50:36.604  2009  2009 W libc    : invalid pthread_t (0) passed to pthread_join

```

Ran the CTS Test also just to confirm

```
07-18 00:13:23 I/DeviceManager: Detected new device 9AUAY1FMD3
07-18 00:16:00 I/DeviceManager: Detected new device 9AUAY1FMD3
cts-tf > run cts --skip-device-info --logcat-on-failure --module CtsBionicTestCases --test pthread#pthread_attr_setstacksize
07-18 00:16:12 I/TestInvocation: Starting invocation for 'cts' with '[ DeviceBuildInfo{bid=6221200, serial=9AUAY1FMD3} on device '9AUAY1FMD3']
07-18 00:16:20 W/PropertyCheck: Expected "user" but found "userdebug" for property: ro.build.type
07-18 00:16:20 W/PropertyCheck: Property "persist.sys.test_harness" not found on device, cannot verify value "false"
07-18 00:16:22 D/ITestSuite: [Total Unique Modules = 2]
07-18 00:16:23 E/PushFilePreparer: Did not find any module directory for 'CtsBionicTestCases'
07-18 00:16:23 E/PushFilePreparer: Did not find any module directory for 'CtsBionicTestCases'
07-18 00:16:29 I/ModuleListener: [1/1] pthread#pthread_attr_setstacksize pass
07-18 00:16:29 I/ConsoleReporter: [9AUAY1FMD3] Starting arm64-v8a CtsBionicTestCases with 1 test
07-18 00:16:29 I/ConsoleReporter: [1/1 arm64-v8a CtsBionicTestCases 9AUAY1FMD3] pthread#pthread_attr_setstacksize pass
07-18 00:16:29 I/ConsoleReporter: [9AUAY1FMD3] arm64-v8a CtsBionicTestCases completed in 704 ms. 1 passed, 0 failed, 0 not executed
07-18 00:16:33 E/PushFilePreparer: Did not find any module directory for 'CtsBionicTestCases'
07-18 00:16:34 E/PushFilePreparer: Did not find any module directory for 'CtsBionicTestCases'
07-18 00:16:42 I/ModuleListener: [1/1] pthread#pthread_attr_setstacksize pass
07-18 00:16:42 I/ConsoleReporter: [9AUAY1FMD3] Starting armeabi-v7a CtsBionicTestCases with 1 test
07-18 00:16:42 I/ConsoleReporter: [1/1 armeabi-v7a CtsBionicTestCases 9AUAY1FMD3] pthread#pthread_attr_setstacksize pass
07-18 00:16:42 I/ConsoleReporter: [9AUAY1FMD3] armeabi-v7a CtsBionicTestCases completed in 813 ms. 1 passed, 0 failed, 0 not executed
07-18 00:16:45 I/SuiteResultReporter:
============================================
================= Results ==================
=============== Consumed Time ==============
    armeabi-v7a CtsBionicTestCases: 813 ms
    arm64-v8a CtsBionicTestCases: 704 ms
Total aggregated tests run time: 1s
============== Modules Preparation Times ==============
    armeabi-v7a CtsBionicTestCases => prep = 7527 ms || clean = 198 ms
    arm64-v8a CtsBionicTestCases => prep = 5898 ms || clean = 162 ms
Total preparation time: 13s  ||  Total tear down time: 360 ms
=======================================================
=============== Summary ===============
Total Run time: 33s
2/2 modules completed
Total Tests       : 2
PASSED            : 2
FAILED            : 0
============== End of Results ==============
============================================
```
