### PR TITLE
linker: Add support for opening zip files by fd paths

### DIFF
--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -831,14 +831,14 @@ class ZipArchiveCache {
   ZipArchiveCache() {}
   ~ZipArchiveCache();
 
-  bool get_or_open(const char* zip_path, ZipArchiveHandle* handle);
+  bool get_or_open(const char* zip_path, int zip_fd, ZipArchiveHandle* handle);
  private:
   DISALLOW_COPY_AND_ASSIGN(ZipArchiveCache);
 
   std::unordered_map<std::string, ZipArchiveHandle> cache_;
 };
 
-bool ZipArchiveCache::get_or_open(const char* zip_path, ZipArchiveHandle* handle) {
+bool ZipArchiveCache::get_or_open(const char* zip_path, int zip_fd, ZipArchiveHandle* handle) {
   std::string key(zip_path);
 
   auto it = cache_.find(key);
@@ -847,7 +847,7 @@ bool ZipArchiveCache::get_or_open(const char* zip_path, ZipArchiveHandle* handle
     return true;
   }
 
-  int fd = TEMP_FAILURE_RETRY(open(zip_path, O_RDONLY | O_CLOEXEC));
+  int fd = zip_fd != -1 ? dup(zip_fd) : TEMP_FAILURE_RETRY(open(zip_path, O_RDONLY | O_CLOEXEC));
   if (fd == -1) {
     return false;
   }
@@ -898,13 +898,19 @@ static int open_library_in_zipfile(ZipArchiveCache* zip_archive_cache,
 
   const char* zip_path = buf;
   const char* file_path = &buf[separator - path + 2];
-  int fd = TEMP_FAILURE_RETRY(open(zip_path, O_RDONLY | O_CLOEXEC));
+  int fd;
+  if (!strncmp("/proc/self/fd/", zip_path, strlen("/proc/self/fd/")) &&
+        sscanf(zip_path, "/proc/self/fd/%d", &fd) == 1) {
+    fd = dup(fd);
+  } else {
+    fd = TEMP_FAILURE_RETRY(open(zip_path, O_RDONLY | O_CLOEXEC));
+  }
   if (fd == -1) {
     return -1;
   }
 
   ZipArchiveHandle handle;
-  if (!zip_archive_cache->get_or_open(zip_path, &handle)) {
+  if (!zip_archive_cache->get_or_open(zip_path, fd, &handle)) {
     // invalid zip-file (?)
     close(fd);
     return -1;


### PR DESCRIPTION
In some cases, it can be useful to load libraries from zip files that are only available by fd reference. For example, file descriptors of APKs containing native libraries may be sent via Binder IPC for clients to use.

Unfortunately, while this linker does support loading libraries from file descriptors using android_dlopen_ext, using that API is not an option because our dlopen calls originate from JNI loadLibrary requests in ART.

This is necessary for compatibility with Google Play Services' dynamic module system (Dynamite) without weakening the SELinux sandbox to allow other apps to open module APKs from `/data/user_de/0/com.google.android.gms/app_chimera/m`.