### PR TITLE
gmscompat: don't use "/proc/self/fd" paths for loading Dynamite modules

### DIFF
--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -910,8 +910,8 @@ static int open_library_in_zipfile(ZipArchiveCache* zip_archive_cache,
   const char* zip_path = buf;
   const char* file_path = &buf[separator - path + 2];
   int fd;
-  if (!strncmp("/proc/self/fd/", zip_path, strlen("/proc/self/fd/")) &&
-        sscanf(zip_path, "/proc/self/fd/%d", &fd) == 1) {
+  if (!strncmp("/gmscompat_fd_", zip_path, strlen("/gmscompat_fd_")) &&
+        sscanf(zip_path, "/gmscompat_fd_%d", &fd) == 1) {
     fd = dup(fd);
   } else {
     fd = TEMP_FAILURE_RETRY(open(zip_path, O_RDONLY | O_CLOEXEC));


### PR DESCRIPTION
dup()-ing fd that is referred to by "/proc/self/fd" path isn't the same
as open()-ing that path. fd that is returned by dup() refers to the same
underlying file description and thus shares position and file status
flags with the original fd.

The ability to pass "/proc/self/fd" path instead of a file path
is an undocumented API on Android, but there are apps that depend on it.