### PR TITLE
never enable GWP-ASan

### DIFF
--- a/libc/bionic/gwp_asan_wrappers.h
+++ b/libc/bionic/gwp_asan_wrappers.h
@@ -35,13 +35,6 @@
 #include "private/bionic_globals.h"
 #include "private/bionic_malloc_dispatch.h"
 
-// Enable GWP-ASan, used by android_mallopt. Should always be called in a
-// single-threaded context.
-bool EnableGwpAsan(const android_mallopt_gwp_asan_options_t& options);
-
-// Hooks for libc to possibly install GWP-ASan.
-bool MaybeInitGwpAsanFromLibc(libc_globals* globals);
-
 // Returns whether GWP-ASan is the provided dispatch table pointer. Used in
 // heapprofd's signal-initialization sequence to determine the intermediate
 // dispatch pointer to use when initing.

--- a/libc/bionic/malloc_common.cpp
+++ b/libc/bionic/malloc_common.cpp
@@ -325,14 +325,6 @@ extern "C" bool android_mallopt(int opcode, void* arg, size_t arg_size) {
   if (opcode == M_SET_ALLOCATION_LIMIT_BYTES) {
     return LimitEnable(arg, arg_size);
   }
-  if (opcode == M_INITIALIZE_GWP_ASAN) {
-    if (arg == nullptr || arg_size != sizeof(android_mallopt_gwp_asan_options_t)) {
-      errno = EINVAL;
-      return false;
-    }
-
-    return EnableGwpAsan(*reinterpret_cast<android_mallopt_gwp_asan_options_t*>(arg));
-  }
   if (opcode == M_MEMTAG_STACK_IS_ON) {
     if (arg == nullptr || arg_size != sizeof(bool)) {
       errno = EINVAL;

--- a/libc/bionic/malloc_common_dynamic.cpp
+++ b/libc/bionic/malloc_common_dynamic.cpp
@@ -382,8 +382,6 @@ static void MallocInitImpl(libc_globals* globals) {
   char prop[PROP_VALUE_MAX];
   char* options = prop;
 
-  MaybeInitGwpAsanFromLibc(globals);
-
 #if defined(USE_SCUDO)
   __libc_shared_globals()->scudo_stack_depot = __scudo_get_stack_depot_addr();
   __libc_shared_globals()->scudo_region_info = __scudo_get_region_info_addr();
@@ -530,14 +528,6 @@ extern "C" bool android_mallopt(int opcode, void* arg, size_t arg_size) {
       return false;
     }
     return FreeMallocLeakInfo(reinterpret_cast<android_mallopt_leak_info_t*>(arg));
-  }
-  if (opcode == M_INITIALIZE_GWP_ASAN) {
-    if (arg == nullptr || arg_size != sizeof(android_mallopt_gwp_asan_options_t)) {
-      errno = EINVAL;
-      return false;
-    }
-
-    return EnableGwpAsan(*reinterpret_cast<android_mallopt_gwp_asan_options_t*>(arg));
   }
   if (opcode == M_MEMTAG_STACK_IS_ON) {
     if (arg == nullptr || arg_size != sizeof(bool)) {


### PR DESCRIPTION
It weakens hardened_malloc protections, especially when memory tagging is enabled.