### PR TITLE
fixup! add XOR mangling mitigation for thread-local dtors

### DIFF
--- a/libc/private/bionic_globals.h
+++ b/libc/private/bionic_globals.h
@@ -46,11 +46,11 @@
 
 struct libc_globals {
   vdso_entry vdso[VDSO_END];
-  long dtor_cookie;
   long setjmp_cookie;
   uintptr_t heap_pointer_tag;
   _Atomic(bool) memtag_stack;
   _Atomic(bool) decay_time_enabled;
+  long dtor_cookie;
 
   // In order to allow a complete switch between dispatch tables without
   // the need for copying each function by function in the structure,


### PR DESCRIPTION
memtag_stack struct member is required to be at its exact position by static_assert below.