### PR TITLE
enable heap memory tagging in vendor processes; ignore heap memory tagging setting overrides on user builds

### DIFF
--- a/libc/bionic/libc_init_static.cpp
+++ b/libc/bionic/libc_init_static.cpp
@@ -272,6 +272,11 @@ static bool get_environment_memtag_setting(HeapTaggingLevel* level) {
     }
   }
 
+  if (!is_debug_build) {
+      // ignore heap memory tagging setting overrides on user builds
+      return false;
+  }
+
   const char* basename = __gnu_basename(progname);
 
   char options_str[PROP_VALUE_MAX];

--- a/libc/bionic/libc_init_static.cpp
+++ b/libc/bionic/libc_init_static.cpp
@@ -246,6 +246,11 @@ static bool starts_with(const char* s, const char* prefix) {
     return strncmp(s, prefix, strlen(prefix)) == 0;
 }
 
+static bool is_debuggable_build() {
+  char pv[8];
+  return get_property_value("ro.debuggable", pv, sizeof(pv)) && strcmp(pv, "1") == 0;
+}
+
 // Returns true if there's an environment setting (either sysprop or env var)
 // that should overwrite the ELF note, and places the equivalent heap tagging
 // level into *level.
@@ -258,12 +263,12 @@ static bool get_environment_memtag_setting(HeapTaggingLevel* level) {
   const char* progname = __libc_shared_globals()->init_progname;
   if (progname == nullptr) return false;
 
-  bool is_vendor_prog = starts_with(progname, "/vendor/") || starts_with(progname, "/apex/com.google.");
-  char prop_value[8];
-  if (is_vendor_prog && get_property_value("persist.arm64.memtag.vendor", prop_value, sizeof(prop_value))) {
-    if (strcmp("1", prop_value) == 0) {
-      *level = M_HEAP_TAGGING_LEVEL_ASYNC;
-      return true;
+  const bool is_vendor_prog = starts_with(progname, "/vendor/") || starts_with(progname, "/apex/com.google.");
+  const bool is_debug_build = is_debuggable_build();
+  if (is_vendor_prog) {
+    *level = M_HEAP_TAGGING_LEVEL_ASYNC;
+    if (!is_debug_build) {
+        return true;
     }
   }
 
@@ -280,7 +285,7 @@ static bool get_environment_memtag_setting(HeapTaggingLevel* level) {
 
   if (!get_config_from_env_or_sysprops("MEMTAG_OPTIONS", sys_prop_names, arraysize(sys_prop_names),
                                        options_str, sizeof(options_str))) {
-    return false;
+    return is_vendor_prog;
   }
 
   if (strcmp("sync", options_str) == 0) {


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/243