### PR TITLE
Reapply "disable memory tagging for Pixel wifi_ext service"

### DIFF
--- a/libc/bionic/libc_init_static.cpp
+++ b/libc/bionic/libc_init_static.cpp
@@ -232,6 +232,7 @@ static bool get_environment_memtag_setting(HeapTaggingLevel* level) {
   if (is_vendor_prog) {
     bool apply_override =
         strcmp(progname, "/apex/com.google.pixel.camera.hal/bin/hw/android.hardware.camera.provider@2.7-service-google")
+        && strcmp(progname, "/apex/com.google.pixel.wifi.ext/bin/hw/vendor.google.wifi_ext-service-vendor")
     ;
     if (apply_override) {
         *level = M_HEAP_TAGGING_LEVEL_ASYNC;


### PR DESCRIPTION
This reverts commit 23fe186a3d64d8f0bc0e46c3b3e461e01ccfab4d.

https://github.com/GrapheneOS/os-issue-tracker/issues/3565 remains an issue in QPR3.