### PR TITLE
Revert "Reapply "disable memory tagging for Pixel wifi_ext service""

### DIFF
--- a/libc/bionic/libc_init_static.cpp
+++ b/libc/bionic/libc_init_static.cpp
@@ -232,7 +232,6 @@ static bool get_environment_memtag_setting(HeapTaggingLevel* level) {
   if (is_vendor_prog) {
     bool apply_override =
         strcmp(progname, "/apex/com.google.pixel.camera.hal/bin/hw/android.hardware.camera.provider@2.7-service-google")
-        && strcmp(progname, "/apex/com.google.pixel.wifi.ext/bin/hw/vendor.google.wifi_ext-service-vendor")
     ;
     if (apply_override) {
         *level = M_HEAP_TAGGING_LEVEL_ASYNC;


### PR DESCRIPTION
Reporting of 2 harmless crashes in this service is now suppressed.

Depends on: https://github.com/GrapheneOS/platform_frameworks_base/pull/561