### PR TITLE
pthread_create: always reserve a guard page above the thread stack

### DIFF
--- a/libc/bionic/pthread_create.cpp
+++ b/libc/bionic/pthread_create.cpp
@@ -237,8 +237,13 @@ ThreadMapping __allocate_thread_mapping(size_t stack_size, size_t stack_guard_si
 #else
   size_t max_gap_size = stack_size / 10;
 #endif
-  // Make sure random stack top guard size are multiples of page size.
+  // Make sure the random stack top guard size is a multiple of the page size,
+  // and always reserve at least one guard page between the stack and the
+  // pthread_internal_t / static TLS region. arc4random_uniform() can return 0,
+  // and align_up(0, page_size) is 0, which would leave no guard page at all
+  // and let a stack overflow silently corrupt pthread_internal_t.
   size_t gap_size = __builtin_align_up(arc4random_uniform(max_gap_size), page_size());
+  if (gap_size == 0) gap_size = page_size();
 
   // Allocate in order: stack guard, stack, (random) guard page(s), pthread_internal_t, static TLS, libgen buffers, guard page.
   size_t mmap_size;


### PR DESCRIPTION
### Summary

The secondary stack randomization introduced in b98b3a853 ("add secondary stack randomization") can produce a `gap_size` of `0`, eliminating the guard page between the thread stack and the writable region containing `pthread_internal_t` and static TLS. This patch ensures at least one guard page is always present.

### Background

Commit e01c20680 ("move pthread_internal_t behind guard page") deliberately placed `pthread_internal_t` behind a fixed `page_size()` PROT_NONE guard so that a stack overflow would fault rather than corrupt thread-local state.

b98b3a853 later replaced that fixed gap with a randomly sized one to also randomize the secondary stack base:

```cpp
size_t gap_size = __builtin_align_up(arc4random_uniform(max_gap_size), page_size());
```

### Bug

`arc4random_uniform(N)` is uniform over `[0, N)` and can return `0`. `__builtin_align_up(0, page_size())` is `0`, so when that single outcome occurs:

- `gap_size == 0`
- The `mprotect(... PROT_READ|PROT_WRITE ...)` for the non-stack region begins immediately after the writable stack, with no PROT_NONE page in between.
- A linear stack overflow silently overwrites `pthread_internal_t` / static TLS instead of trapping.

(Inputs in `[1, page_size()-1]` are *not* affected — they round **up** to `page_size()` and produce a valid one-page guard.)

The probability is therefore `1 / max_gap_size` per `pthread_create()`, e.g. roughly `1 / 4,194,304` on 64-bit with the default 8 MiB stack and 4 KiB pages. Rare, but real, and defeats the hardening guarantee.

The surrounding comment block still claims `(random) guard page(s)` between stack and `pthread_internal_t`, confirming this is unintended.

### Fix

```diff
   size_t gap_size = __builtin_align_up(arc4random_uniform(max_gap_size), page_size());
+  if (gap_size == 0) gap_size = page_size();
```

Preserves randomization for all non-zero outcomes while restoring the invariant that there is always at least one PROT_NONE page separating the thread stack from `pthread_internal_t` / static TLS — matching the comments and the intent of the earlier guard-page commit.

The clamp introduces a negligible bias (probability mass of `page_size()` increases by `1/max_gap_size`), which has no effect on the security property of the guard region.

### Impact

- Hardening: closes a small but real hole where stack overflow no longer faults.
- Behavior: no API/ABI change, no measurable perf impact (single branch + assignment).
- Compatibility: layout falls back to a single guard page (the pre-randomization behavior) only in the `gap_size == 0` case.