### PR TITLE
fix h_malloc_wrapper integration for Cuttlefish builds

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -185,7 +185,7 @@ cc_defaults {
             ],
         },
         lib64: {
-            srcs: ["bionic/h_malloc_wrapper.cpp"],
+            srcs: [":libc_h_malloc_wrapper_src"],
             cflags: [
                 "-DH_MALLOC_PREFIX",
                 "-DUSE_H_MALLOC",
@@ -211,7 +211,7 @@ cc_library_static {
             static_libs: ["libjemalloc5"],
         },
         lib64: {
-            srcs: ["bionic/h_malloc_wrapper.cpp"],
+            srcs: [":libc_h_malloc_wrapper_src"],
             static_libs: ["libhardened_malloc"],
         },
     },
@@ -1387,6 +1387,11 @@ cc_library_static {
         "libc_init_static",
         "libc_unwind_static",
     ],
+}
+
+filegroup {
+    name: "libc_h_malloc_wrapper_src",
+    srcs: ["bionic/h_malloc_wrapper.cpp"],
 }
 
 filegroup {


### PR DESCRIPTION
Fixes build errors:

error: frameworks/libs/native_bridge_support/android_api/libc/Android.bp:27:1: m
  odule "libnative_bridge_guest_libc" variant "android_native_bridge_arm64_armv8-a
  _static": module source path "frameworks/libs/native_bridge_support/android_api/
  libc/bionic/h_malloc_wrapper.cpp" does not exist

Test: lunch aosp_cf_x86_64_only_phone-cur-userdebug with hardened_malloc fix boots