### PR TITLE
disable MTE for Widevine Rikers service

### DIFF
--- a/libc/bionic/libc_init_mte.cpp
+++ b/libc/bionic/libc_init_mte.cpp
@@ -136,6 +136,7 @@ static bool get_environment_memtag_setting(HeapTaggingLevel* level) {
     get_property_value("ro.product.name", device_name, sizeof(device_name));
     bool apply_override =
         strcmp(progname, "/apex/com.google.pixel.camera.hal/bin/hw/android.hardware.camera.provider@2.7-service-google") != 0
+        && strcmp(progname, "/apex/com.google.android.widevine/bin/hw/android.hardware.drm-service.widevine-rikers") != 0
         && (
             (
                  strcmp(device_name, "tokay") != 0


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8051

Widevine Rikers is the proprietary Widevine DRM HAL service.  In the crash path, its internal resolver decodes requested symbol names such as signal, uses GNU hash metadata to find the matching libc .dynsym entry, and caches the resolved function pointer. The faulting PC is the resolver’s `ldg x8, [x8] instruction` at Rikers offset 0x11c51e8, where x8 points at execute-only libc text for `signal@@LIBC`, causing SEGV_ACCERR when MTE is enabled.

All the tests suites below have encountered failures with the SEGV_ACCERR prior to this commit.

Test: atest CtsMediaDrmFrameworkTestCases
Test: atest CtsVirtualDevicesAppLaunchTestCases:android.virtualdevice.cts.applaunch.VirtualDeviceDrmTest
Test: atest VtsAidlHalDrmTargetTest (requires userdebug with locked bootloader)