### PR TITLE
fix pointer aliasing in malloc dispatch tables in InitNativeAllocatorDispatch

### DIFF
--- a/libc/bionic/malloc_common.cpp
+++ b/libc/bionic/malloc_common.cpp
@@ -443,9 +443,8 @@ void InitNativeAllocatorDispatch(libc_globals* globals) {
     &__scudo_malloc_dispatch;
 
   if (!hardened_impl) {
-    globals->malloc_dispatch_table = __scudo_malloc_dispatch;
-    globals->current_dispatch_table = &globals->malloc_dispatch_table;
-    globals->default_dispatch_table = &globals->malloc_dispatch_table;
+    globals->current_dispatch_table = &__scudo_malloc_dispatch;
+    globals->default_dispatch_table = &__scudo_malloc_dispatch;
   }
 
   native_allocator_dispatch = table;


### PR DESCRIPTION

The aliased malloc dispatch table can cause issues with malloc debug.

(the following is pasted from https://github.com/GrapheneOS/platform_bionic/pull/70#issuecomment-4430767291 )


Inside MallocInitImpl, it first calls InitNativeAllocatorDispatch, which sets both globals->current_dispatch_table and globals->default_dispatch_table to the address of globals->malloc_dispatch_table.

Then it calls InstallHooks when MallocDebug is enabled, which then calls 1. LoadSharedLibrary and then 2. FinishInstallHooks.

LoadSharedLibrary loads the globals->malloc_dispatch_table with the malloc debug functions. Due to the aliasing, globals->current_dispatch_table and globals->default_dispatch_table are also set to the malloc debug functions.

Then in FinishInstallHooks, debug_initialize is called in the following code
```
  const MallocDispatch* prev_dispatch = GetDefaultDispatchTable();
  if (prev_dispatch == nullptr) {
    prev_dispatch = NativeAllocatorDispatch();
  }

  if (!init_func(prev_dispatch, &gZygoteChild, options)) {
    error_log("%s: failed to enable malloc %s", getprogname(), prefix);
    ClearGlobalFunctions();
    return false;
  }
```
This means that debug_initialize is not going to be able to properly save prev_dispatch due to the aliasing as it is already overridden by LoadSharedLibrary.