### PR TITLE
__pthread_internal_remap_stack_with_mte: stop setting stack top guard to RW

### DIFF
--- a/libc/bionic/pthread_create.cpp
+++ b/libc/bionic/pthread_create.cpp
@@ -331,6 +331,8 @@ ThreadMapping __allocate_thread_mapping(size_t stack_size, size_t stack_guard_si
   // than the space originally wasted by pthread_internal_t for compatibility.
   result.stack_top = space + stack_guard_size + stack_size - arc4random_uniform(sizeof(pthread_internal_t));
   result.stack_top = __builtin_align_down(result.stack_top, 16);
+
+  result.stack_size = stack_size;
   return result;
 }
 
@@ -390,6 +392,7 @@ static int __allocate_thread(pthread_attr_t* attr, bionic_tcb** tcbp, void** chi
   thread->mmap_size_unguarded = mapping.mmap_size_unguarded;
   thread->stack_top = reinterpret_cast<uintptr_t>(stack_top);
   thread->stack_bottom = reinterpret_cast<uintptr_t>(attr->stack_base);
+  thread->stack_size = mapping.stack_size;
 
   *tcbp = tcb;
   *child_stack = stack_top;

--- a/libc/bionic/pthread_internal.cpp
+++ b/libc/bionic/pthread_internal.cpp
@@ -226,7 +226,7 @@ bool __pthread_internal_remap_stack_with_mte() {
   }
   for (pthread_internal_t* t = g_thread_list; t != nullptr; t = t->next) {
     if (t->terminating || t->is_main()) continue;
-    if (mprotect(t->mmap_base_unguarded, t->mmap_size_unguarded,
+    if (t->stack_size && mprotect(t->mmap_base_unguarded, t->stack_size,
                  PROT_READ | PROT_WRITE | PROT_MTE)) {
       async_safe_fatal("error: failed to set PROT_MTE on thread: %d", t->tid);
     }

--- a/libc/bionic/pthread_internal.h
+++ b/libc/bionic/pthread_internal.h
@@ -168,6 +168,8 @@ class pthread_internal_t {
   size_t mmap_size_unguarded;
   char vma_name_buffer[32];
 
+  size_t stack_size;
+
   thread_local_dtor* thread_local_dtors;
 
   /*
@@ -198,6 +200,7 @@ struct ThreadMapping {
   char* static_tls;
   char* stack_base;
   char* stack_top;
+  size_t stack_size;
   char* libgen_buffers;
 };
 

--- a/tests/struct_layout_test.cpp
+++ b/tests/struct_layout_test.cpp
@@ -30,7 +30,7 @@ void tests(CheckSize check_size, CheckOffset check_offset) {
 #define CHECK_OFFSET(name, field, offset) \
     check_offset(#name, #field, offsetof(name, field), offset)
 #ifdef __LP64__
-  CHECK_SIZE(pthread_internal_t, 832);
+  CHECK_SIZE(pthread_internal_t, 840);
   CHECK_OFFSET(pthread_internal_t, next, 0);
   CHECK_OFFSET(pthread_internal_t, prev, 8);
   CHECK_OFFSET(pthread_internal_t, tid, 16);
@@ -51,14 +51,15 @@ void tests(CheckSize check_size, CheckOffset check_offset) {
   CHECK_OFFSET(pthread_internal_t, mmap_base_unguarded, 192);
   CHECK_OFFSET(pthread_internal_t, mmap_size_unguarded, 200);
   CHECK_OFFSET(pthread_internal_t, vma_name_buffer, 208);
-  CHECK_OFFSET(pthread_internal_t, thread_local_dtors, 240);
-  CHECK_OFFSET(pthread_internal_t, current_dlerror, 248);
-  CHECK_OFFSET(pthread_internal_t, dlerror_buffer, 256);
-  CHECK_OFFSET(pthread_internal_t, bionic_tls, 768);
-  CHECK_OFFSET(pthread_internal_t, errno_value, 776);
-  CHECK_OFFSET(pthread_internal_t, bionic_tcb, 784);
-  CHECK_OFFSET(pthread_internal_t, stack_mte_ringbuffer_vma_name_buffer, 792);
-  CHECK_OFFSET(pthread_internal_t, should_allocate_stack_mte_ringbuffer, 824);
+  CHECK_OFFSET(pthread_internal_t, stack_size, 240);
+  CHECK_OFFSET(pthread_internal_t, thread_local_dtors, 248);
+  CHECK_OFFSET(pthread_internal_t, current_dlerror, 256);
+  CHECK_OFFSET(pthread_internal_t, dlerror_buffer, 264);
+  CHECK_OFFSET(pthread_internal_t, bionic_tls, 776);
+  CHECK_OFFSET(pthread_internal_t, errno_value, 784);
+  CHECK_OFFSET(pthread_internal_t, bionic_tcb, 792);
+  CHECK_OFFSET(pthread_internal_t, stack_mte_ringbuffer_vma_name_buffer, 800);
+  CHECK_OFFSET(pthread_internal_t, should_allocate_stack_mte_ringbuffer, 832);
   CHECK_SIZE(bionic_tls, 4016);
   CHECK_OFFSET(bionic_tls, key_data, 0);
   CHECK_OFFSET(bionic_tls, locale, 2080);
@@ -75,7 +76,7 @@ void tests(CheckSize check_size, CheckOffset check_offset) {
   CHECK_OFFSET(bionic_tls, bionic_systrace_enabled, 4009);
   CHECK_OFFSET(bionic_tls, padding, 4010);
 #else
-  CHECK_SIZE(pthread_internal_t, 712);
+  CHECK_SIZE(pthread_internal_t, 716);
   CHECK_OFFSET(pthread_internal_t, next, 0);
   CHECK_OFFSET(pthread_internal_t, prev, 4);
   CHECK_OFFSET(pthread_internal_t, tid, 8);
@@ -96,14 +97,15 @@ void tests(CheckSize check_size, CheckOffset check_offset) {
   CHECK_OFFSET(pthread_internal_t, mmap_base_unguarded, 104);
   CHECK_OFFSET(pthread_internal_t, mmap_size_unguarded, 108);
   CHECK_OFFSET(pthread_internal_t, vma_name_buffer, 112);
-  CHECK_OFFSET(pthread_internal_t, thread_local_dtors, 144);
-  CHECK_OFFSET(pthread_internal_t, current_dlerror, 148);
-  CHECK_OFFSET(pthread_internal_t, dlerror_buffer, 152);
-  CHECK_OFFSET(pthread_internal_t, bionic_tls, 664);
-  CHECK_OFFSET(pthread_internal_t, errno_value, 668);
-  CHECK_OFFSET(pthread_internal_t, bionic_tcb, 672);
-  CHECK_OFFSET(pthread_internal_t, stack_mte_ringbuffer_vma_name_buffer, 676);
-  CHECK_OFFSET(pthread_internal_t, should_allocate_stack_mte_ringbuffer, 708);
+  CHECK_OFFSET(pthread_internal_t, stack_size, 144);
+  CHECK_OFFSET(pthread_internal_t, thread_local_dtors, 148);
+  CHECK_OFFSET(pthread_internal_t, current_dlerror, 152);
+  CHECK_OFFSET(pthread_internal_t, dlerror_buffer, 156);
+  CHECK_OFFSET(pthread_internal_t, bionic_tls, 668);
+  CHECK_OFFSET(pthread_internal_t, errno_value, 672);
+  CHECK_OFFSET(pthread_internal_t, bionic_tcb, 676);
+  CHECK_OFFSET(pthread_internal_t, stack_mte_ringbuffer_vma_name_buffer, 680);
+  CHECK_OFFSET(pthread_internal_t, should_allocate_stack_mte_ringbuffer, 712);
   CHECK_SIZE(bionic_tls, 2892);
   CHECK_OFFSET(bionic_tls, key_data, 0);
   CHECK_OFFSET(bionic_tls, locale, 1040);


### PR DESCRIPTION
(the following is pasted from #67 )
pthread_create.cpp __allocate_thread_mapping does the following:
```
// Layout from the end of the mmap-ed region (before the top PTHREAD_GUARD_SIZE):
//
// [ PTHREAD_GUARD_SIZE ]
// [ libgen_buffers_padded_size (for dedicated page(s) for libgen buffers) ]
// [ static_tls_layout_size ]
// [ thread_page_size (for pthread_internal_t) ]
// [ gap_size (for (random) guard page(s)) ]
// [ stack_size ]
// [ stack_guard_size ]

ThreadMapping result = {};
result.mmap_base = space;
result.mmap_size = mmap_size;
result.mmap_base_unguarded = space + stack_guard_size;
result.mmap_size_unguarded = mmap_size - stack_guard_size - PTHREAD_GUARD_SIZE;
```

This means that after
```
mprotect(t->mmap_base_unguarded, t->mmap_size_unguarded,
                 PROT_READ | PROT_WRITE | PROT_MTE)
```
is executed in __pthread_internal_remap_stack_with_mte, the stack top guard is set to RW.
This PR proposes a fix for this issue.