### PR TITLE
fix iconv out-of-bounds read in //IGNORE/TRANSLIT

### DIFF
--- a/libc/bionic/iconv.cpp
+++ b/libc/bionic/iconv.cpp
@@ -129,7 +129,10 @@ struct __iconv_t {
     dst_bytes_left = dst_bytes_left0;
 
     while (*src_bytes_left > 0) {
-      if (!GetNext() || !Convert()) return -1;
+      Result r = GetNext();
+      if (r == Result::kError) return -1;
+      if (r == Result::kSkip) continue;
+      if (!Convert()) return -1;
     }
     return Done();
   }
@@ -149,7 +152,10 @@ struct __iconv_t {
   char** dst_buf;
   size_t* dst_bytes_left;
 
-  bool GetNext() {
+  // kSkip means //IGNORE already consumed an illegal sequence: skip Convert().
+  enum class Result { kOk, kSkip, kError };
+
+  Result GetNext() {
     errno = 0;
     switch (src_encoding) {
       case US_ASCII:
@@ -161,10 +167,13 @@ struct __iconv_t {
       case UTF_8:
         src_bytes_used = mbrtoc32(&wc, *src_buf, *src_bytes_left, &ps);
         if (src_bytes_used == BIONIC_MULTIBYTE_RESULT_ILLEGAL_SEQUENCE) {
-          break;  // EILSEQ already set.
+          // EILSEQ already set. Clamp the (size_t)-1 so the //IGNORE and
+          // //TRANSLIT source advances below don't wrap out of bounds.
+          src_bytes_used = 1;
+          break;
         } else if (src_bytes_used == BIONIC_MULTIBYTE_RESULT_INCOMPLETE_SEQUENCE) {
           errno = EINVAL;
-          return false;
+          return Result::kError;
         }
         break;
 
@@ -172,7 +181,7 @@ struct __iconv_t {
       case UTF_16_LE: {
         if (*src_bytes_left < 2) {
           errno = EINVAL;
-          return false;
+          return Result::kError;
         }
         bool swap = (src_encoding == UTF_16_BE);
         wc = In16(*src_buf, swap);
@@ -181,11 +190,11 @@ struct __iconv_t {
         if (wc >= 0xd800 && wc <= 0xdfff) {
           if (wc >= 0xdc00) {  // Low surrogate before high surrogate.
             errno = EILSEQ;
-            return false;
+            return Result::kError;
           }
           if (*src_bytes_left < 4) {
             errno = EINVAL;
-            return false;
+            return Result::kError;
           }
           uint16_t hi = wc;
           uint16_t lo = In16(*src_buf + 2, swap);
@@ -200,7 +209,7 @@ struct __iconv_t {
       case WCHAR_T:
         if (*src_bytes_left < 4) {
           errno = EINVAL;
-          return false;
+          return Result::kError;
         }
         wc = In32(*src_buf, (src_encoding == UTF_32_BE));
         break;
@@ -209,19 +218,19 @@ struct __iconv_t {
     if (errno == EILSEQ) {
       switch (mode) {
         case ERROR:
-          return false;
+          return Result::kError;
         case IGNORE:
           *src_buf += src_bytes_used;
           *src_bytes_left -= src_bytes_used;
           ignored = true;
-          return GetNext();
+          return Result::kSkip;
         case TRANSLIT:
           wc = '?';
           ++replacement_count;
-          return true;
+          return Result::kOk;
       }
     }
-    return true;
+    return Result::kOk;
   }
 
   bool Convert() {

--- a/tests/iconv_test.cpp
+++ b/tests/iconv_test.cpp
@@ -123,6 +123,206 @@ TEST(iconv, iconv_lossy_IGNORE) {
   ASSERT_EQ(0, iconv_close(c));
 }
 
+// An illegal source sequence in //IGNORE or //TRANSLIT mode must skip the
+// offending bytes, not advance the source by mbrtoc32()'s (size_t)-1 result.
+TEST(iconv, iconv_IGNORE_malformed_utf8_middle) {
+  const char* utf8 = "a\xffz"; // 0xff is never a valid UTF-8 byte.
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//IGNORE", "UTF-8");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(utf8);
+  size_t in_bytes = 3;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  EXPECT_ERRNO_FAILURE(EILSEQ, static_cast<size_t>(-1), iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ('z', buf[1]);
+  EXPECT_EQ(0, buf[2]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf) - 2, out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
+TEST(iconv, iconv_IGNORE_malformed_utf8_only) {
+  const char* utf8 = "\xff";
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//IGNORE", "UTF-8");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(utf8);
+  size_t in_bytes = 1;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  EXPECT_ERRNO_FAILURE(EILSEQ, static_cast<size_t>(-1), iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ(0, buf[0]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf), out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
+TEST(iconv, iconv_IGNORE_malformed_utf8_trailing) {
+  const char* utf8 = "az\xff";
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//IGNORE", "UTF-8");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(utf8);
+  size_t in_bytes = 3;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  EXPECT_ERRNO_FAILURE(EILSEQ, static_cast<size_t>(-1), iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ('z', buf[1]);
+  EXPECT_EQ(0, buf[2]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf) - 2, out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
+TEST(iconv, iconv_TRANSLIT_malformed_utf8) {
+  const char* utf8 = "a\xffz";
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//TRANSLIT", "UTF-8");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(utf8);
+  size_t in_bytes = 3;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  EXPECT_EQ(1U, iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ('?', buf[1]);
+  EXPECT_EQ('z', buf[2]);
+  EXPECT_EQ(0, buf[3]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf) - 3, out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
+TEST(iconv, iconv_IGNORE_invalid_ascii_trailing) {
+  const char* ascii = "a\x80"; // 0x80 is > 0x7f, so not ASCII.
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//IGNORE", "ASCII");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(ascii);
+  size_t in_bytes = 2;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  EXPECT_ERRNO_FAILURE(EILSEQ, static_cast<size_t>(-1), iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ(0, buf[1]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf) - 1, out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
+TEST(iconv, iconv_IGNORE_consecutive_malformed_utf8) {
+  const char* utf8 = "a\xff\xffz";
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//IGNORE", "UTF-8");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(utf8);
+  size_t in_bytes = 4;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  EXPECT_ERRNO_FAILURE(EILSEQ, static_cast<size_t>(-1), iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ('z', buf[1]);
+  EXPECT_EQ(0, buf[2]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf) - 2, out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
+TEST(iconv, iconv_IGNORE_all_malformed_utf8) {
+  const char* utf8 = "\xff\xff\xff";
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//IGNORE", "UTF-8");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(utf8);
+  size_t in_bytes = 3;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  EXPECT_ERRNO_FAILURE(EILSEQ, static_cast<size_t>(-1), iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ(0, buf[0]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf), out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
+TEST(iconv, iconv_IGNORE_malformed_multibyte_utf8) {
+  // Only the lead byte is skipped, not the whole intended sequence length.
+  const char* utf8 = "a\xe2\xe2z"; // 0xe2 starts a 3-byte sequence; 0xe2 is a bad continuation.
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//IGNORE", "UTF-8");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(utf8);
+  size_t in_bytes = 4;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  EXPECT_ERRNO_FAILURE(EILSEQ, static_cast<size_t>(-1), iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ('z', buf[1]);
+  EXPECT_EQ(0, buf[2]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf) - 2, out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
+TEST(iconv, iconv_TRANSLIT_consecutive_malformed_utf8) {
+  const char* utf8 = "a\xff\xffz";
+  char buf[BUFSIZ] = {};
+
+  iconv_t c = iconv_open("UTF-8//TRANSLIT", "UTF-8");
+  ASSERT_NE(INVALID_ICONV_T, c);
+
+  char* in = const_cast<char*>(utf8);
+  size_t in_bytes = 4;
+  char* out = buf;
+  size_t out_bytes = sizeof(buf);
+
+  // Each illegal byte becomes one '?' replacement.
+  EXPECT_EQ(2U, iconv(c, &in, &in_bytes, &out, &out_bytes));
+  EXPECT_EQ('a', buf[0]);
+  EXPECT_EQ('?', buf[1]);
+  EXPECT_EQ('?', buf[2]);
+  EXPECT_EQ('z', buf[3]);
+  EXPECT_EQ(0, buf[4]);
+  EXPECT_EQ(0U, in_bytes);
+  EXPECT_EQ(sizeof(buf) - 4, out_bytes);
+
+  ASSERT_EQ(0, iconv_close(c));
+}
+
 TEST(iconv, iconv_lossy) {
   const char* utf8 = "a٦ᄀz"; // U+0666 ٦ 0xd9 0xa6 // U+1100 ᄀ 0xe1 0x84 0x80
   char buf[BUFSIZ] = {};


### PR DESCRIPTION
mbrtoc32() reports an illegal UTF-8 sequence by returning (size_t)-1. In //IGNORE and //TRANSLIT mode the source is then advanced by that value, wrapping the source pointer backwards and growing the remaining-byte counter, so the conversion reads out of bounds and can loop without terminating. The //IGNORE path also recurses into GetNext() without re-checking the remaining length, letting a US-ASCII source read past the end of the buffer.

Clamp the illegal-sequence length to one byte and replace the recursion with a skip handled by the conversion loop, so an illegal sequence skips a single byte and the loop re-checks the remaining input.

Add regression tests for illegal bytes in //IGNORE and //TRANSLIT mode.